### PR TITLE
fix: satisfy linting god without failing ourselves

### DIFF
--- a/internal/socket/unixconn.go
+++ b/internal/socket/unixconn.go
@@ -32,11 +32,8 @@ func UnixConnWrap(obj any) (*net.UnixConn, error) {
 		return nil, err
 	}
 
-	wg := new(sync.WaitGroup)
-
 	// if the object implements io.Reader: read from the object and write to the reverseUnixConn
 	if reader, ok := obj.(io.Reader); ok {
-		wg.Add(1)
 		go func() {
 			_, _ = io.Copy(reverseUnixConn, reader)
 
@@ -45,13 +42,11 @@ func UnixConnWrap(obj any) (*net.UnixConn, error) {
 			log.Debugf("closing reverseUnixConn and unixConn")
 			err = reverseUnixConn.Close()
 			err = unixConn.Close()
-			wg.Done()
 		}()
 	}
 
 	// if the object implements io.Writer: read from the reverseUnixConn and write to the object
 	if writer, ok := obj.(io.Writer); ok {
-		wg.Add(1)
 		go func() {
 			_, _ = io.Copy(writer, reverseUnixConn)
 			// when the src is closed, we will close the dst
@@ -60,11 +55,9 @@ func UnixConnWrap(obj any) (*net.UnixConn, error) {
 				log.Debugf("closing obj")
 				_ = closer.Close()
 			}
-			wg.Done()
 		}()
 	}
 
-	wg.Wait()
 	return unixConn, nil
 }
 
@@ -80,11 +73,8 @@ func UnixConnFileWrap(obj any) (*os.File, error) {
 		return nil, err
 	}
 
-	wg := new(sync.WaitGroup)
-
 	// if the object implements io.Reader: read from the object and write to the reverseUnixConn
 	if reader, ok := obj.(io.Reader); ok {
-		wg.Add(1)
 		go func() {
 			_, _ = io.Copy(reverseUnixConn, reader)
 			// when the src is closed, we will close the dst
@@ -93,13 +83,11 @@ func UnixConnFileWrap(obj any) (*os.File, error) {
 			reverseUnixConn.Close()
 			_ = unixConn.Close()
 			_ = unixConnFile.Close()
-			wg.Done()
 		}()
 	}
 
 	// if the object implements io.Writer: read from the reverseUnixConn and write to the object
 	if writer, ok := obj.(io.Writer); ok {
-		wg.Add(1)
 		go func() {
 			_, _ = io.Copy(writer, reverseUnixConn)
 			// when the src is closed, we will close the dst
@@ -108,11 +96,9 @@ func UnixConnFileWrap(obj any) (*os.File, error) {
 				log.Debugf("closing obj")
 				_ = closer.Close()
 			}
-			wg.Done()
 		}()
 	}
 
-	wg.Wait()
 	return unixConnFile, nil
 }
 

--- a/transport/v0/conn.go
+++ b/transport/v0/conn.go
@@ -224,10 +224,10 @@ func (c *Conn) Close() (err error) {
 	c.closeOnce.Do(func() {
 		log.Debugf("Defering TM")
 		c.tm.DeferAll()
-		log.Debugf("Cleaning TM")
-		c.tm.Cleanup()
 		log.Debugf("Canceling TM")
 		err = c.tm.Cancel()
+		log.Debugf("Cleaning TM")
+		c.tm.Cleanup()
 		log.Debugf("TM canceled")
 	})
 


### PR DESCRIPTION
- Remove the bad waiting groups 👿
- Fix order of execution in closing a connection: the cancel channel should be used BEFORE cleaned up not after. 

----

Fix #9. 