### PR TITLE
fix: README.md CI badge source

### DIFF
--- a/.github/workflows/water.yml
+++ b/.github/workflows/water.yml
@@ -116,7 +116,7 @@ jobs:
           go-version: "1.22.x"
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     </div>
 </div>
 
-To build a WATM in Go, please refer to [watm](https://github.com/refraction-networking/water/watm) for examples and helper libraries interfacing Pluggable Transports-like interfaces. Official Go compiler is currently not supported until further notice.
+To build a WATM in Go, please refer to [watm](https://github.com/refraction-networking/water/tree/master/watm) for examples and helper libraries interfacing Pluggable Transports-like interfaces. Official Go compiler is currently not supported until further notice.
 
 You can contact one of developers personally via gaukas.wang@colorado.edu, or simply [opening an issue](https://github.com/refraction-networking/water/issues/new). 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-green)
 ![GPLv3](https://img.shields.io/badge/License-GPL--3.0-red)
 [![FOSSA](https://app.fossa.com/api/projects/git%2Bgithub.com%2Frefraction-networking%2Fwater.svg?type=shield&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Frefraction-networking%2Fwater?ref=badge_shield&issueType=license)
-[![CI](https://github.com/refraction-networking/water/actions/workflows/go.yml/badge.svg?branch=master)](https://github.com/refraction-networking/water/actions/workflows/go.yml)
+[![CI](https://github.com/refraction-networking/water/actions/workflows/water.yml/badge.svg?branch=master)](https://github.com/refraction-networking/water/actions/workflows/water.yml)
 [![Go Doc](https://pkg.go.dev/badge/github.com/refraction-networking/water.svg)](https://pkg.go.dev/github.com/refraction-networking/water)
 
 <div style="width: 100%; height = 160px">


### PR DESCRIPTION
The badge needs to be updated to pointing to water.yml since the source workflow has been renamed. 