### PR TITLE
docs: update WATM link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
     </div>
 </div>
 
-To build a WATM in Go, please refer to [watm](https://github.com/refraction-networking/water/tree/master/watm) for examples and helper libraries interfacing Pluggable Transports-like interfaces. Official Go compiler is currently not supported until further notice.
+To build a WATM in Go, please refer to [watm](https://github.com/refraction-networking/watm) for examples and helper libraries interfacing Pluggable Transports-like interfaces. Official Go compiler is currently not supported until further notice.
 
 You can contact one of developers personally via gaukas.wang@colorado.edu, or simply [opening an issue](https://github.com/refraction-networking/water/issues/new). 
 


### PR DESCRIPTION
in README.md a link was pointing to the embedded sub module which has been removed since v0.6.2